### PR TITLE
Fix Flux compatibility with newer ComfyUI

### DIFF
--- a/flux/layers.py
+++ b/flux/layers.py
@@ -66,7 +66,7 @@ class NAGDoubleStreamBlock(DoubleStreamBlock):
         img_k_negative = img_k[-origin_bsz:]
         img_v_negative = img_v[-origin_bsz:]
 
-        if self.flipped_img_txt:
+        if getattr(self, "flipped_img_txt", True):
             # run actual attention
             attn_negative = attention(
                 torch.cat((img_q_negative, txt_q_negative), dim=2),

--- a/flux/model.py
+++ b/flux/model.py
@@ -615,7 +615,7 @@ class NAGFlux(Flux):
             txt_ids = torch.zeros((bs, context.shape[1], 3), device=x.device, dtype=x.dtype)
             # Call base Flux.forward_orig directly to avoid issues if self.forward_orig was left in NAG state
             out = Flux.forward_orig(
-                self, img, img_ids, context, txt_ids, timestep, y, guidance, control, transformer_options,
+                self, img, img_ids, context, txt_ids, timestep, y, guidance, control, None, transformer_options,
                 attn_mask=kwargs.get("attention_mask", None),
             )
 


### PR DESCRIPTION
This fixes a Flux sampling crash in newer ComfyUI versions where `DoubleStreamBlock` doesn't expose `flipped_img_txt`.

The crash was:

`AttributeError: 'DoubleStreamBlock' object has no attribute 'flipped_img_txt'`

This changes the direct attribute access to:

```python
getattr(self, "flipped_img_txt", True)
```

so older behavior is preserved while avoiding the AttributeError.

This also fixes a newer ComfyUI `Flux.forward_orig` signature change. ComfyUI now has `timestep_zero_index` before `transformer_options`, so the fallback positional call needs to pass `None` in that slot to keep `transformer_options` aligned correctly.